### PR TITLE
Fail tests if input is mutated

### DIFF
--- a/fixtures/060-list-issue.js
+++ b/fixtures/060-list-issue.js
@@ -1,0 +1,1405 @@
+module.exports = {
+  input: [
+    {
+      '_key': '68e32a42bc86',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'h2'
+    },
+    {
+      '_key': 'e5a6349a2145',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '22659f66b40b',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'number',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '87b8d684fb9e',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'number',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'a14d35e806c5',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'number',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '4bc360f7123a',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'number',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '22f50c9e40a6',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'number',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '664cca534e5d',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'number',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '1e9b2d0b4ef6',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'number',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '24ede750fde5',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'number',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '89eeaeac72c5',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'number',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '993fb23a4fbb',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'number',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '09b00b82c010',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'h2'
+    },
+    {
+      '_key': 'e1ec0b8bccbe',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'ff11fb1a52ad',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '034604cee2d9',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '836431a777a8',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'h2'
+    },
+    {
+      '_key': 'a2c1052ca675',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [
+            'abaab54abef7'
+          ],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [
+            '36e7c773d148'
+          ],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [
+            '4352c44c3077'
+          ],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [
+        {
+          '_key': 'abaab54abef7',
+          '_type': 'link',
+          'href': 'https://example.com'
+        },
+        {
+          '_key': '36e7c773d148',
+          '_type': 'link',
+          'href': 'https://example.com'
+        },
+        {
+          '_key': '4352c44c3077',
+          '_type': 'link',
+          'href': 'https://example.com'
+        }
+      ],
+      'style': 'normal'
+    },
+    {
+      '_key': '008e004a87e3',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'h3'
+    },
+    {
+      '_key': '383dddd69bef',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'ea36cba89a66',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '57f05ea5c2bb',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'd5df37eee363',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'h3'
+    },
+    {
+      '_key': '61231e9bb2f4',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'e1091120de4d',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'be53f0b95e8b',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'e6538941fddf',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'a852b3d1518a',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'd77890703306',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'd061261ee1d2',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'h3'
+    },
+    {
+      '_key': '248cc45717e0',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '09f2ab44df66',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'ba7b45509071',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [
+            'em'
+          ],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '12c77502a595',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'h3'
+    },
+    {
+      '_key': '078039a7af96',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'e2ea9480bfe5',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'fdc3bfe19845',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '3201b3d02e0d',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '5ef716ee0309',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'h3'
+    },
+    {
+      '_key': '9a1430f39842',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '5fa8c1cd9d66',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '29240861e0c7',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'h3'
+    },
+    {
+      '_key': '471105eb4eb6',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '2a1754271e84',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'c820d890f8c7',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'h3'
+    },
+    {
+      '_key': 'b58650f53e9e',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '0ca5f3fb129e',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'f68449f61111',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 2,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '5433045c560a',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 2,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '3d85b3b16d79',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 2,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '03421acc9f6d',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 2,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '3a94842ddd74',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '4e3558037479',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 2,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '2cf4b5ddec6f',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 2,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '93051319ac3e',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 2,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '252749bb01d5',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 2,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'd32eb8106d08',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 2,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'dbdbc5839fb6',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 2,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'f673698e2e27',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 2,
+      'listItem': 'bullet',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '2638df8609e7',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'h2'
+    },
+    {
+      '_key': '8bd25d26c0ab',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '58fc3993c18c',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [
+            'em'
+          ],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '7845e645190f',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'h2'
+    },
+    {
+      '_key': '26e1555ec20c',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'e90b29141e56',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '7f9ac906a4bd',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'h2'
+    },
+    {
+      '_key': '9259af58c8be',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'd3343fe575d4',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'number',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '14c57fd646e8',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'number',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'c8e8905dfe9e',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'number',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '69c4fe9fa4ed',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'number',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'ae19d6d44753',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'number',
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '1136f698594f',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': 'd94cdd676b75',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'h2'
+    },
+    {
+      '_key': '660d22bd8f2a',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'normal'
+    },
+    {
+      '_key': '55c6814da883',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [
+            '96b9a7384bb9'
+          ],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [
+        {
+          '_key': '96b9a7384bb9',
+          '_type': 'link',
+          'href': 'https://example.com'
+        }
+      ],
+      'style': 'normal'
+    },
+    {
+      '_key': '2baca0a20bca',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [
+            '99d77e03056c'
+          ],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [
+        {
+          '_key': '99d77e03056c',
+          '_type': 'link',
+          'href': 'https://example.com'
+        }
+      ],
+      'style': 'normal'
+    },
+    {
+      '_key': '512d2c9cc40d',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [
+            'a81f3f515e3e'
+          ],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [
+        {
+          '_key': 'a81f3f515e3e',
+          '_type': 'link',
+          'href': 'https://example.com'
+        }
+      ],
+      'style': 'normal'
+    },
+    {
+      '_key': '5e68d8b50d64',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [
+            'aedfb56c1761'
+          ],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [
+        {
+          '_key': 'aedfb56c1761',
+          '_type': 'link',
+          'href': 'https://example.com'
+        }
+      ],
+      'style': 'normal'
+    },
+    {
+      '_key': '8d339b91184a',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [
+            'beec3b2a0459'
+          ],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [
+        {
+          '_key': 'beec3b2a0459',
+          '_type': 'link',
+          'href': 'https://example.com'
+        }
+      ],
+      'style': 'normal'
+    },
+    {
+      '_key': '09d48934ea88',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [
+            '30559cd94434'
+          ],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [
+        {
+          '_key': '30559cd94434',
+          '_type': 'link',
+          'href': 'https://example.com'
+        }
+      ],
+      'style': 'normal'
+    },
+    {
+      '_key': '851a44421210',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [
+            'cf109fae377a'
+          ],
+          'text': 'Lorem ipsum'
+        },
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'level': 1,
+      'listItem': 'bullet',
+      'markDefs': [
+        {
+          '_key': 'cf109fae377a',
+          '_type': 'link',
+          'href': 'https://example.com'
+        }
+      ],
+      'style': 'normal'
+    },
+    {
+      '_key': 'b584b7aee2be',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'h2'
+    },
+    {
+      '_key': '23e9756111da',
+      '_type': 'block',
+      'children': [
+        {
+          '_type': 'span',
+          'marks': [],
+          'text': 'Lorem ipsum'
+        }
+      ],
+      'markDefs': [],
+      'style': 'normal'
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "eslint-config-prettier": "^2.6.0",
     "eslint-config-sanity": "^3.1.0",
     "prettier": "^1.7.4"
+  },
+  "dependencies": {
+    "require-all": "^2.2.0"
   }
 }

--- a/tests.js
+++ b/tests.js
@@ -13,7 +13,11 @@ module.exports = function runTests(opts = {}) {
       .forEach(fixture => {
         const originalInput = JSON.parse(JSON.stringify(fixture.input))
         const passedInput = fixture.input
-        render({blocks: passedInput})
+        try {
+          render({blocks: passedInput})
+        } catch (error) {
+          // ignore
+        }
         expect(originalInput).toEqual(passedInput)
       })
   })

--- a/tests.js
+++ b/tests.js
@@ -1,9 +1,22 @@
 const identity = inp => inp
 const defaults = {normalize: identity}
+const requireAll = require('require-all')
+const fixtures = requireAll(`${__dirname  }/fixtures`)
 
 module.exports = function runTests(opts = {}) {
   const options = Object.assign({}, defaults, opts)
   const {render, h, normalize, getImageUrl} = options
+
+  test('never mutates input', () => {
+    Object.keys(fixtures)
+      .map(name => fixtures[name])
+      .forEach(fixture => {
+        const originalInput = JSON.parse(JSON.stringify(fixture.input))
+        const passedInput = fixture.input
+        render({blocks: passedInput})
+        expect(originalInput).toEqual(passedInput)
+      })
+  })
 
   test('builds empty tree on empty block', () => {
     const {input, output} = require('./fixtures/001-empty-block')


### PR DESCRIPTION
This adds a test that fails if the render function mutates its input. This will cause block-content-to-hyperscript to fail, which seems to be the cause of the bug we're currently tracking down.